### PR TITLE
[EXE-1641] Fix take and limit in pushdown query

### DIFF
--- a/src/it/scala/io/github/spark_redshift_community/spark/redshift/RedshiftReadSuite.scala
+++ b/src/it/scala/io/github/spark_redshift_community/spark/redshift/RedshiftReadSuite.scala
@@ -72,6 +72,16 @@ class RedshiftReadSuite extends IntegrationSuiteBase {
     // scalastyle:on
   }
 
+  test("Pushdown limit and take") {
+    val df1 = sqlContext.sql("select teststring from test_table")
+    assert(df1.take(1).length === 1L)
+    assert(RedshiftPushDownSqlStatement.capturedQueries.exists(_.contains("LIMIT 1")))
+
+    val df2 = sqlContext.sql("select teststring from test_table limit 5")
+    assert(df2.count() === 5L)
+    assert(RedshiftPushDownSqlStatement.capturedQueries.exists(_.contains("LIMIT 5")))
+  }
+
   test("count() on DataFrame created from a Redshift table") {
     checkAnswer(
       sqlContext.sql("select count(*) from test_table"),

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/RedshiftPushDownQuery.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/RedshiftPushDownQuery.scala
@@ -241,12 +241,9 @@ case class SortLimitQueryRedshift(limit: Option[Expression],
         new RedshiftPushDownSqlStatement()
       }
 
-    // TODO need to change limit to top for azure
-
     statementFirstPart + limit
       .map(ConstantString("LIMIT") + expressionToStatement(_))
       .getOrElse(new RedshiftPushDownSqlStatement())
-    statementFirstPart
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq5"
+version in ThisBuild := "5.1.0-aiq6"


### PR DESCRIPTION
Bring in https://github.com/ActionIQ/flame/pull/461/files#diff-45a1ff3afb55a4a5ec3f5d86236d33653b3e2b9eb533a5e40a6f9e9db7073924L264;
Adding tests

`sbt test`
`sbt "it:testOnly io.github.spark_redshift_community.spark.redshift.RedshiftReadSuite"`