### PR TITLE
[DP-1][Epic] Hybrid Compute Observability Fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import sbtrelease.ReleasePlugin.autoImport._
 import scoverage.ScoverageKeys
 
-val sparkVersion = "3-3-2-aiq2092"
+val sparkVersion = "3-3-2-aiq95"
 
 // Define a custom test configuration so that unit test helper classes can be re-used under
 // the integration tests configuration; see http://stackoverflow.com/a/20635808.

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 import sbtrelease.ReleasePlugin.autoImport._
 import scoverage.ScoverageKeys
 
-val sparkVersion = "3-3-2-aiq88"
+val sparkVersion = "3-3-2-aiq2092"
 
 // Define a custom test configuration so that unit test helper classes can be re-used under
 // the integration tests configuration; see http://stackoverflow.com/a/20635808.

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -185,7 +185,13 @@ private[redshift] case class RedshiftRelation(
 
     if (telemetryMetrics.logStatistics) {
       sqlContext.sparkContext.emitMetricsLog(
-        telemetryMetrics.compileTelemetryTagsMap()
+        telemetryMetrics.compileTelemetryTagsMap() map {
+          case (DATASOURCE_TELEMETRY_READ_ROW_COUNT, _) =>
+            // There isn't a good way to calculate the row count for the
+            // RDD other than rdd.count() which is a costly operation
+            DATASOURCE_TELEMETRY_READ_ROW_COUNT -> "N/A"
+          case t => t
+        }
       )
     }
     rdd

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -155,8 +155,10 @@ private[redshift] case class RedshiftRelation(
       val rs = jdbcWrapper.executeQueryInterruptibly(
         conn.prepareStatement("select pg_last_unload_count()")
       )
-      while (rs.next) {
+      if (rs.next()) {
         readRowCount = rs.getLong(1)
+      } else {
+        log.info(logEventNameTagger("Could not read row count from Redshift"))
       }
 
     } finally {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -158,7 +158,7 @@ private[redshift] case class RedshiftRelation(
       if (rs.next()) {
         readRowCount = rs.getLong(1)
       } else {
-        log.info(logEventNameTagger("Could not read row count from Redshift"))
+        log.info(logEventNameTagger("Could not read Unload row count from Redshift"))
       }
 
     } finally {

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -107,11 +107,10 @@ private[redshift] case class RedshiftRelation(
       val results = jdbcWrapper.executeQueryInterruptibly(conn.prepareStatement(queryWithTag))
       if (results.next()) {
         val numRows = results.getLong(1)
-        telemetryMetrics.incrementRowCount()
-
         val parallelism = sqlContext.getConf("spark.sql.shuffle.partitions", "200").toInt
         val emptyRow = RowEncoder(StructType(Seq.empty)).createSerializer().apply(Row(Seq.empty))
 
+        telemetryMetrics.incrementRowCount()
         val rdd = sqlContext.sparkContext
           .parallelize(1L to numRows, parallelism)
           .map(_ => emptyRow)

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -222,7 +222,7 @@ private[redshift] case class RedshiftRelation(
   ): RDD[InternalRow] = {
     val queryString = statement.toString
 
-    val dataWarehouse = Option(sqlContext.sparkContext.getLocalProperty("dataSource"))
+    val dataWarehouse = Option(sqlContext.sparkContext.getLocalProperty("dataWarehouse"))
     log.info(
       logEventNameTagger(
         "Generated Query with extra PushDown\n" +

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -185,11 +185,7 @@ private[redshift] case class RedshiftRelation(
 
     if (telemetryMetrics.logStatistics) {
       sqlContext.sparkContext.emitMetricsLog(
-        telemetryMetrics.compileTelemetryTagsMap() map {
-          case (DATASOURCE_TELEMETRY_READ_ROW_COUNT, _) =>
-            DATASOURCE_TELEMETRY_READ_ROW_COUNT -> rdd.count().toString
-          case t => t
-        }
+        telemetryMetrics.compileTelemetryTagsMap()
       )
     }
     rdd

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -174,6 +174,7 @@ private[redshift] case class RedshiftRelation(
       }
     }
 
+    // Capturing the time of the "first row count"
     telemetryMetrics.incrementRowCount()
     val rdd = sqlContext.read
       .format(classOf[RedshiftFileFormat].getName)

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/RedshiftRelation.scala
@@ -139,7 +139,6 @@ private[redshift] case class RedshiftRelation(
     // Unload data from Redshift into a temporary directory in S3:
     val tempDir = params.createPerQueryTempDir()
     val unloadSql = buildUnloadStmt(query, tempDir, creds, params.sseKmsKey)
-    val unloadSqlWithTag = RedshiftPushDownSqlStatement.appendTagsToQuery(jdbcOptions, unloadSql)
     val conn = jdbcWrapper.getConnector(params)
 
     sqlContext.sparkContext.emitMetricsLog(
@@ -149,7 +148,7 @@ private[redshift] case class RedshiftRelation(
     telemetryMetrics.setQuerySubmissionTime()
 
     try {
-      jdbcWrapper.executeInterruptibly(conn.prepareStatement(unloadSqlWithTag))
+      jdbcWrapper.executeInterruptibly(conn.prepareStatement(unloadSql))
     } finally {
       conn.close()
     }

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownPlan.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownPlan.scala
@@ -24,10 +24,12 @@ package io.github.spark_redshift_community.spark.redshift.pushdowns
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, UnsafeProjection}
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{SQLPlan, SparkPlan}
 import org.apache.spark.sql.types.{StructField, StructType}
 
-case class RedshiftPushDownPlan(output: Seq[Attribute], rdd: RDD[InternalRow], sql: String) extends SparkPlan {
+case class RedshiftPushDownPlan(output: Seq[Attribute], rdd: RDD[InternalRow], sql: String)
+  extends SparkPlan with SQLPlan {
+
   override def children: Seq[SparkPlan] = Nil
   protected override def doExecute(): RDD[InternalRow] = {
 

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownStrategy.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownStrategy.scala
@@ -74,9 +74,8 @@ class RedshiftPushDownStrategy(sparkContext: SparkContext)
   }
 
   private def foundRedshiftRelation(plan: LogicalPlan): Boolean = {
-    plan match {
+    plan.collectFirst {
       case LogicalRelation(r, _, _, _) if r.isInstanceOf[RedshiftRelation] => true
-      case _ => false
-    }
+    }.getOrElse(false)
   }
 }

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownStrategy.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/RedshiftPushDownStrategy.scala
@@ -75,7 +75,7 @@ class RedshiftPushDownStrategy(sparkContext: SparkContext)
 
   private def foundRedshiftRelation(plan: LogicalPlan): Boolean = {
     plan.collectFirst {
-      case LogicalRelation(r, _, _, _) if r.isInstanceOf[RedshiftRelation] => true
+      case LogicalRelation(_: RedshiftRelation, _, _, _) => true
     }.getOrElse(false)
   }
 }

--- a/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/UnsupportedStatement.scala
+++ b/src/main/scala/io/github/spark_redshift_community/spark/redshift/pushdowns/querygeneration/UnsupportedStatement.scala
@@ -17,10 +17,9 @@
 
 package io.github.spark_redshift_community.spark.redshift.pushdowns.querygeneration
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, PythonUDF, ScalaUDF}
-import org.apache.spark.sql.execution.aggregate.ScalaUDAF
-
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import io.github.spark_redshift_community.spark.redshift.RedshiftPushDownSqlStatement
+import org.apache.spark.sql.execution.datasources.jdbc.pushdowns.querygeneration.QueryPushdownUnsupportedException
 
 private[querygeneration] object UnsupportedStatement {
   /** Used mainly by QueryGeneration.convertStatement. This matches
@@ -41,15 +40,12 @@ private[querygeneration] object UnsupportedStatement {
     // This exception is not a real issue. It will be caught in
     // QueryBuilder. It can't be done here
     // because it is not clear whether there are any cloud tables here.
-    throw new IllegalArgumentException(
-      "failed to pushdown")
-  }
-
-  // Determine whether the unsupported operation is known or not.
-  private def isKnownUnsupportedOperation(expr: Expression): Boolean = {
-    // The pushdown for UDF is known unsupported
-    (expr.isInstanceOf[PythonUDF]
-      || expr.isInstanceOf[ScalaUDF]
-      || expr.isInstanceOf[ScalaUDAF])
+    throw new QueryPushdownUnsupportedException(
+      "PushDown failed because of an unsupported " +
+        s"operation=${expr.prettyName} and candidate sql=${expr.sql}",
+      "UnsupportedStatement",
+      expr.prettyName,
+      expr.sql
+    )
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq15-yt1"
+version in ThisBuild := "5.1.0-aiq15"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq15-yt4"
+version in ThisBuild := "5.1.0-aiq15"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq2092"
+version in ThisBuild := "5.1.0-aiq15-yt1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq15"
+version in ThisBuild := "5.1.0-aiq15-yt4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq14"
+version in ThisBuild := "5.1.0-aiq2092"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq15-yt6"
+version in ThisBuild := "5.1.0-aiq15"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "5.1.0-aiq15"
+version in ThisBuild := "5.1.0-aiq15-yt6"


### PR DESCRIPTION
- Pick up and setup https://github.com/ActionIQ/flame/pull/595 and https://github.com/ActionIQ/flame/pull/598
- Log Tagging for easier debugging

## Test Notes
```
-> % sbt "clean; compile;"
...
[success] Total time: 8 s, completed Jul 12, 2024, 6:25:08 PM
```

```
2024-07-12T20:41:39.950+0000 INFO [SparkLauncherChild-1] RedshiftRelation t=5c66715fc97c6879 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|segment_id=380591" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_380591_1720816862279_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] Generated Query with extra PushDown
'SELECT ( SUBQUERY_1.customer_id ) AS SUBQUERY_2_COL_0 FROM ( SELECT * FROM ( SELECT * FROM qahybridredshift.rd_dim_customer AS REDSHIFT_QUERY_ALIAS ) AS SUBQUERY_0 WHERE ( SUBQUERY_0.customer_id IS NOT NULL ) ) AS SUBQUERY_1'
in redshift

2024-07-12T20:41:40.020+0000 INFO [SparkLauncherChild-1] SparkContext t=5c66715fc97c6879 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|segment_id=380591" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_380591_1720816862279_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712204123-0000 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_sql=</* partner:actioniq_hybridcompute */
UNLOAD ('SELECT ( SUBQUERY_1.customer_id ) AS SUBQUERY_2_COL_0 FROM ( SELECT * FROM ( SELECT * FROM qahybridredshift.rd_dim_customer AS REDSHIFT_QUERY_ALIAS ) AS SUBQUERY_0 WHERE ( SUBQUERY_0.customer_id IS NOT NULL ) ) AS SUBQUERY_1') TO 's3://aiq-1d-expire-dev/redshift/109/b1cf88dc-e9a9-4cf7-b784-51e2e5f7a8a8/' WITH CREDENTIALS 'aws_iam_role=arn:aws:iam::938824509083:role/johnwu-testRedshift-community-jdbc-role' ESCAPE MANIFEST NULL AS '@NULL@' > hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=0 hybrid_compute.datasource_telemetry.data_warehouse=redshift

2024-07-12T20:41:45.939+0000 INFO [SparkLauncherChild-1] SparkContext t=5c66715fc97c6879 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|segment_id=380591" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_380591_1720816862279_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712204123-0000 hybrid_compute.datasource_telemetry.application_started_at=2024-07-12T20:41:22.925Z hybrid_compute.datasource_telemetry.read_column_count=0 hybrid_compute.datasource_telemetry.last_row_read_at=N/A event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_submission_latency_millis=17095 hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.warehouse_read_latency_millis=N/A hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.first_row_read_at=N/A hybrid_compute.datasource_telemetry.warehouse_query_latency_millis=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=0 hybrid_compute.datasource_telemetry.data_warehouse=redshift hybrid_compute.datasource_telemetry.rdd_metrics_source=N/A hybrid_compute.datasource_telemetry.query_submitted_at=2024-07-12T20:41:40.020Z hybrid_compute.datasource_telemetry.read_row_count=17147303

2024-07-12T20:41:59.193+0000 INFO [SparkLauncherChild-1] SparkContext t=5c66715fc97c6879 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|segment_id=380591" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_380591_1720816862279_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712204123-0000 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_sql=</* partner:actioniq_hybridcompute */
UNLOAD ('SELECT ( SUBQUERY_1.customer_id ) AS SUBQUERY_2_COL_0 FROM ( SELECT * FROM ( SELECT * FROM qahybridredshift.rd_dim_customer AS REDSHIFT_QUERY_ALIAS ) AS SUBQUERY_0 WHERE ( ( SUBQUERY_0.optin_status IS NOT NULL ) AND ( ( SUBQUERY_0.customer_id IS NOT NULL ) AND SUBQUERY_0.optin_status ) ) ) AS SUBQUERY_1') TO 's3://aiq-1d-expire-dev/redshift/109/a88fd73b-8fe7-46bc-9e6c-c1f26aaf37f9/' WITH CREDENTIALS 'aws_iam_role=arn:aws:iam::938824509083:role/johnwu-testRedshift-community-jdbc-role' ESCAPE MANIFEST NULL AS '@NULL@' > hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=1 hybrid_compute.datasource_telemetry.data_warehouse=redshift

2024-07-12T20:42:01.120+0000 INFO [SparkLauncherChild-1] SparkContext t=5c66715fc97c6879 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|segment_id=380591" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_380591_1720816862279_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712204123-0000 hybrid_compute.datasource_telemetry.application_started_at=2024-07-12T20:41:22.925Z hybrid_compute.datasource_telemetry.read_column_count=0 hybrid_compute.datasource_telemetry.last_row_read_at=N/A event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_submission_latency_millis=36268 hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.warehouse_read_latency_millis=N/A hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.first_row_read_at=N/A hybrid_compute.datasource_telemetry.warehouse_query_latency_millis=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=1 hybrid_compute.datasource_telemetry.data_warehouse=redshift hybrid_compute.datasource_telemetry.rdd_metrics_source=N/A hybrid_compute.datasource_telemetry.query_submitted_at=2024-07-12T20:41:59.193Z hybrid_compute.datasource_telemetry.read_row_count=8574944

2024-07-12T20:42:11.955+0000 INFO [SparkLauncherChild-1] SparkContext t=5c66715fc97c6879 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|segment_id=380591" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_380591_1720816862279_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712204123-0000 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_sql=</* partner:actioniq_hybridcompute */
UNLOAD ('SELECT ( SUBQUERY_7.SUBQUERY_7_COL_0 ) AS SUBQUERY_8_COL_0 FROM ( SELECT ( SUBQUERY_6.SUBQUERY_6_COL_0 ) AS SUBQUERY_7_COL_0 FROM ( SELECT ( SUBQUERY_2.SUBQUERY_2_COL_0 ) AS SUBQUERY_6_COL_0 , ( SUBQUERY_5.SUBQUERY_5_COL_0 ) AS SUBQUERY_6_COL_1 FROM ( SELECT ( SUBQUERY_1.customer_id ) AS SUBQUERY_2_COL_0 FROM ( SELECT * FROM ( SELECT * FROM qahybridredshift.rd_dim_customer AS REDSHIFT_QUERY_ALIAS ) AS SUBQUERY_0 WHERE ( SUBQUERY_0.customer_id IS NOT NULL ) ) AS SUBQUERY_1 ) AS SUBQUERY_2 INNER JOIN ( SELECT ( SUBQUERY_4.customer_id ) AS SUBQUERY_5_COL_0 FROM ( SELECT * FROM ( SELECT * FROM qahybridredshift.rd_dim_customer_demographics_test AS REDSHIFT_QUERY_ALIAS ) AS SUBQUERY_3 WHERE ( ( SUBQUERY_3.education_status IS NOT NULL ) AND ( ( SUBQUERY_3.customer_id IS NOT NULL ) AND ( LOWER ( SUBQUERY_3.education_status ) = \'4 yr degree\' ) ) ) ) AS SUBQUERY_4 ) AS SUBQUERY_5 ON ( SUBQUERY_2.SUBQUERY_2_COL_0 = SUBQUERY_5.SUBQUERY_5_COL_0 ) ) AS SUBQUERY_6 ) AS SUBQUERY_7 GROUP BY SUBQUERY_7.SUBQUERY_7_COL_0') TO 's3://aiq-1d-expire-dev/redshift/109/d6086168-e86f-45f8-aeaa-7ba092678a5a/' WITH CREDENTIALS 'aws_iam_role=arn:aws:iam::938824509083:role/johnwu-testRedshift-community-jdbc-role' ESCAPE MANIFEST NULL AS '@NULL@' > hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=2 hybrid_compute.datasource_telemetry.data_warehouse=redshift

2024-07-12T20:42:35.072+0000 INFO [SparkLauncherChild-1] SparkContext t=5c66715fc97c6879 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|segment_id=380591" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_380591_1720816862279_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712204123-0000 hybrid_compute.datasource_telemetry.application_started_at=2024-07-12T20:41:22.925Z hybrid_compute.datasource_telemetry.read_column_count=0 hybrid_compute.datasource_telemetry.last_row_read_at=N/A event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_submission_latency_millis=49030 hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.warehouse_read_latency_millis=N/A hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.first_row_read_at=N/A hybrid_compute.datasource_telemetry.warehouse_query_latency_millis=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=2 hybrid_compute.datasource_telemetry.data_warehouse=redshift hybrid_compute.datasource_telemetry.rdd_metrics_source=N/A hybrid_compute.datasource_telemetry.query_submitted_at=2024-07-12T20:42:11.955Z hybrid_compute.datasource_telemetry.read_row_count=2456373

2024-07-12T20:42:47.423+0000 INFO [spark-listener-group-shared] SparkContext t=5c66715fc97c6879 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|segment_id=380591" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_380591_1720816862279_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712204123-0000 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.number_of_queries_submitted_failed_pushdown=0 hybrid_compute.datasource_telemetry.number_of_queries_submitted=4
```

<img width="700" alt="Screenshot 2024-07-12 at 23 44 13" src="https://github.com/user-attachments/assets/10a7afff-ba20-4622-9446-032bb6343f98">

<img width="510" alt="Screenshot 2024-07-12 at 23 44 40" src="https://github.com/user-attachments/assets/9df613ba-4b2a-4dad-a5e4-d8c29ea28a50">

<img width="697" alt="Screenshot 2024-07-12 at 23 45 33" src="https://github.com/user-attachments/assets/61bb1a7b-4f24-47bf-9b88-5ea25dabaf5d">

<img width="483" alt="Screenshot 2024-07-12 at 23 46 09" src="https://github.com/user-attachments/assets/bb5d8ea0-65ec-4b1a-a9d7-5ae86eae8369">

<img width="723" alt="Screenshot 2024-07-12 at 23 46 54" src="https://github.com/user-attachments/assets/9154dc0e-e845-4167-870b-c7a799829fa3">

<img width="501" alt="Screenshot 2024-07-12 at 23 47 23" src="https://github.com/user-attachments/assets/fa10b353-0bf3-44a1-8442-477aa4f220d9">

<img width="569" alt="Screenshot 2024-07-12 at 23 47 55" src="https://github.com/user-attachments/assets/d1899c9d-d4f4-4ecf-b262-aa2a54df8bc0">

```
2024-07-12T20:57:08.279+0000 INFO [SparkLauncherChild-1] QueryBuilder t=29081b8566305cc8 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|variable_id=88374" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_88374_1720817810881_0 execId=driver - [event_name=hybrid_compute.datasource_telemetry] [hybrid_compute.datasource_telemetry.failure_log=true] PushDown failed in hybrid_compute.datasource_telemetry.function=UnsupportedStatement for hybrid_compute.datasource_telemetry.operation=scalaudf trying to process "string_to_date(clicked_at, yyyy-MM-dd HH:mm:ss, UTC)"

2024-07-12T20:57:13.143+0000 INFO [SparkLauncherChild-1] SparkContext t=29081b8566305cc8 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|variable_id=88374" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_88374_1720817810881_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712205702-0001 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_sql=</* partner:actioniq_hybridcompute */
UNLOAD ('SELECT "customer_id", "clicked_at" FROM "qahybridredshift"."rd_fct_clickstream" WHERE "customer_id" IS NOT NULL') TO 's3://aiq-1d-expire-dev/redshift/109/2a9561f4-5b56-4fd0-8496-47c770dfdbed/' WITH CREDENTIALS 'aws_iam_role=arn:aws:iam::938824509083:role/johnwu-testRedshift-community-jdbc-role' ESCAPE MANIFEST NULL AS '@NULL@' > hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=1 hybrid_compute.datasource_telemetry.data_warehouse=redshift

2024-07-12T20:57:26.781+0000 INFO [SparkLauncherChild-1] SparkContext t=29081b8566305cc8 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|variable_id=88374" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_88374_1720817810881_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712205702-0001 hybrid_compute.datasource_telemetry.application_started_at=2024-07-12T20:57:02.004Z hybrid_compute.datasource_telemetry.read_column_count=0 hybrid_compute.datasource_telemetry.last_row_read_at=N/A event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.query_submission_latency_millis=11139 hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.warehouse_read_latency_millis=N/A hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.first_row_read_at=N/A hybrid_compute.datasource_telemetry.warehouse_query_latency_millis=N/A hybrid_compute.datasource_telemetry.connector_type=spark_connector hybrid_compute.datasource_telemetry.query_id=1 hybrid_compute.datasource_telemetry.data_warehouse=redshift hybrid_compute.datasource_telemetry.rdd_metrics_source=N/A hybrid_compute.datasource_telemetry.query_submitted_at=2024-07-12T20:57:13.143Z hybrid_compute.datasource_telemetry.read_row_count=678914732

2024-07-12T21:02:21.802+0000 INFO [spark-listener-group-shared] SparkContext t=29081b8566305cc8 c=109 appFamily=Count crossRunId="customer_id=109|family=Count|variable_id=88374" appName=yannis-testing-hc-all_hybridbricksiq_109_Count_88374_1720817810881_0 execId=driver - hybrid_compute.datasource_telemetry.application_id=app-20240712205702-0001 event_name=hybrid_compute.datasource_telemetry hybrid_compute.datasource_telemetry.pushdown_flag_enabled=true hybrid_compute.datasource_telemetry.application_attempt_id=N/A hybrid_compute.datasource_telemetry.number_of_queries_submitted_failed_pushdown=1 hybrid_compute.datasource_telemetry.number_of_queries_submitted=2
```

<img width="706" alt="Screenshot 2024-07-13 at 00 01 32" src="https://github.com/user-attachments/assets/c0bfc901-2775-427f-b8be-f693a4e57bdd">

<img width="494" alt="Screenshot 2024-07-13 at 00 02 00" src="https://github.com/user-attachments/assets/bcea3a33-225f-42e1-ac18-ca919a85e483">

<img width="572" alt="Screenshot 2024-07-13 at 00 02 59" src="https://github.com/user-attachments/assets/8a8b1644-5ab5-4fcb-bdc6-7036eb0ab9c9">

## Deploy Notes
- Merge and `sbt publish`
- Pick up new Connector version in Flame
- Deploy new Clusters